### PR TITLE
chore(commitlint): up max commit body len

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -18,5 +18,6 @@ module.exports = {
   extends: ['@commitlint/config-conventional'],
   rules: {
     'scope-case': [2, 'always', ['pascal-case', 'camel-case', 'kebab-case']],
+    'body-max-line-length': [2, 'always', 150],
   },
 };


### PR DESCRIPTION
-  Semantic Release creates a commit body that is too long for our current ruleset. Upping the commit body length to 150.