### PR TITLE
fix(reducer): ensure loading state is in sync

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ __diff_output__
 *.bak
 *.cya
 .vscode
+*.tgz

--- a/__tests__/useFetchye.spec.jsx
+++ b/__tests__/useFetchye.spec.jsx
@@ -286,4 +286,31 @@ describe('useFetchye', () => {
       });
     });
   });
+
+  describe('With provider', () => {
+    [
+      ['FetchyeReduxProvider', ReduxSetup],
+      ['FetchyeProvider', FetchyeProvider],
+    ].forEach(([name, AFetchyeProvider]) => {
+      describe(name, () => {
+        it('ensures fetch is called once per key', async () => {
+          const fakeFetchClient = jest.fn();
+          global.fetch = fakeFetchClient;
+          render(
+            <AFetchyeProvider cache={cache}>
+              {React.createElement(() => {
+                useFetchye('http://example.com');
+                return null;
+              })}
+              {React.createElement(() => {
+                useFetchye('http://example.com');
+                return null;
+              })}
+            </AFetchyeProvider>
+          );
+          expect(fakeFetchClient).toHaveBeenCalledTimes(1);
+        });
+      });
+    });
+  });
 });

--- a/src/useFetchye.js
+++ b/src/useFetchye.js
@@ -30,7 +30,8 @@ const passInitialData = (value, initialValue, numOfRenders) => (numOfRenders ===
 export const useFetchye = (
   key,
   { mapOptionsToKey = (options) => options, ...options } = { },
-  fetcher) => {
+  fetcher
+) => {
   const {
     defaultFetcher, useFetchyeSelector, dispatch, fetchClient,
   } = useFetchyeContext();
@@ -40,6 +41,7 @@ export const useFetchye = (
   // create a render version manager using refs
   const numOfRenders = useRef(0);
   numOfRenders.current += 1;
+
   useEffect(() => {
     if (options.defer || !computedKey) {
       return;
@@ -55,6 +57,7 @@ export const useFetchye = (
       });
     }
   });
+
   return {
     isLoading: isLoading({
       loading: selectorState.current.loading,

--- a/src/useRefReducer.js
+++ b/src/useRefReducer.js
@@ -1,0 +1,13 @@
+import { useRef } from 'react';
+
+const useRefReducer = (reducer, initialState, notify) => {
+  const state = useRef(initialState);
+
+  const dispatch = (action) => {
+    state.current = reducer(state.current, action);
+    notify();
+  };
+  return [state, dispatch];
+};
+
+export default useRefReducer;

--- a/src/useSubscription.js
+++ b/src/useSubscription.js
@@ -1,0 +1,20 @@
+import { useRef } from 'react';
+
+const useSubscription = () => {
+  const subscribers = useRef(new Set());
+  return [
+    function notify() {
+      subscribers.current.forEach((callback) => {
+        callback();
+      });
+    },
+    function subscribe(callback) {
+      subscribers.current.add(callback);
+      return () => {
+        subscribers.current.delete(callback);
+      };
+    },
+  ];
+};
+
+export default useSubscription;


### PR DESCRIPTION
If multiple cases of `useFetchye` with the same key being rendered in the same cycle state would not be updated across these instances. This resulted in multiple fetch calls being made for the same resource.