### PR TITLE
Release v1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,23 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 1.0.1 (2020-11-17)
+
+
+### Bug Fixes
+
+* **lerna-publish:** syntax ([#32](https://github.com/americanexpress/fetchye/issues/32)) ([21bcc7d](https://github.com/americanexpress/fetchye/commit/21bcc7d840d39c8e7a6e2e2cb95d85fdc1c6b372))
+
+
+### Features
+
+* **all:** initial oss release ([7532d2b](https://github.com/americanexpress/fetchye/commit/7532d2b72cb8930c9b6ebff386ebb101f7879b70))
+* **fetchye:** prepare for initial release [skip ci] ([#28](https://github.com/americanexpress/fetchye/issues/28)) ([2b212df](https://github.com/americanexpress/fetchye/commit/2b212df8fab4405e2b7c51ad687a280cfe27ebbd))
+
+
+
+
+
 # 1.0.0 (2020-11-12)
 
 

--- a/lerna.json
+++ b/lerna.json
@@ -10,5 +10,5 @@
       "allowBranch": "chore/release-*"
     }
   },
-  "version": "1.0.0"
+  "version": "1.0.1"
 }

--- a/packages/fetchye-core/CHANGELOG.md
+++ b/packages/fetchye-core/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 1.0.1 (2020-11-17)
+
+
+### Features
+
+* **fetchye:** prepare for initial release [skip ci] ([#28](https://github.com/americanexpress/fetchye/issues/28)) ([2b212df](https://github.com/americanexpress/fetchye/commit/2b212df8fab4405e2b7c51ad687a280cfe27ebbd))
+
+
+
+
+
 # 1.0.0 (2020-11-12)
 
 

--- a/packages/fetchye-core/package.json
+++ b/packages/fetchye-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fetchye-core",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Core components of the Fetchye library",
   "license": "Apache-2.0",
   "main": "lib/index.js",

--- a/packages/fetchye-immutable-cache/CHANGELOG.md
+++ b/packages/fetchye-immutable-cache/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 1.0.1 (2020-11-17)
+
+
+### Features
+
+* **fetchye:** prepare for initial release [skip ci] ([#28](https://github.com/americanexpress/fetchye/issues/28)) ([2b212df](https://github.com/americanexpress/fetchye/commit/2b212df8fab4405e2b7c51ad687a280cfe27ebbd))
+
+
+
+
+
 # 1.0.0 (2020-11-12)
 
 

--- a/packages/fetchye-immutable-cache/package.json
+++ b/packages/fetchye-immutable-cache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fetchye-immutable-cache",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Immutable cache library to use with fetchye.",
   "license": "Apache-2.0",
   "main": "lib/index.js",
@@ -42,7 +42,7 @@
     "@babel/core": "7.11.6",
     "babel-preset-amex": "^3.4.1",
     "cross-env": "^7.0.2",
-    "fetchye-test-utils": "^1.0.0",
+    "fetchye-test-utils": "^1.0.1",
     "redux": "^4.0.5",
     "rimraf": "^3.0.2"
   },

--- a/packages/fetchye-one-app/CHANGELOG.md
+++ b/packages/fetchye-one-app/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 1.0.1 (2020-11-17)
+
+
+### Features
+
+* **fetchye:** prepare for initial release [skip ci] ([#28](https://github.com/americanexpress/fetchye/issues/28)) ([2b212df](https://github.com/americanexpress/fetchye/commit/2b212df8fab4405e2b7c51ad687a280cfe27ebbd))
+
+
+
+
+
 # 1.0.0 (2020-11-12)
 
 

--- a/packages/fetchye-one-app/package.json
+++ b/packages/fetchye-one-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fetchye-one-app",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Collection of helpers to aid fetchye integration with One App",
   "license": "Apache-2.0",
   "main": "lib/index.js",
@@ -40,10 +40,10 @@
   ],
   "dependencies": {
     "@babel/runtime": "^7.11.2",
-    "fetchye-core": "^1.0.0",
-    "fetchye-immutable-cache": "^1.0.0",
-    "fetchye-redux-provider": "^1.0.0",
-    "fetchye-test-utils": "^1.0.0",
+    "fetchye-core": "^1.0.1",
+    "fetchye-immutable-cache": "^1.0.1",
+    "fetchye-redux-provider": "^1.0.1",
+    "fetchye-test-utils": "^1.0.1",
     "invariant": "^2.2.4",
     "prop-types": "^15.7.2"
   },

--- a/packages/fetchye-redux-provider/CHANGELOG.md
+++ b/packages/fetchye-redux-provider/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 1.0.1 (2020-11-17)
+
+
+### Features
+
+* **fetchye:** prepare for initial release [skip ci] ([#28](https://github.com/americanexpress/fetchye/issues/28)) ([2b212df](https://github.com/americanexpress/fetchye/commit/2b212df8fab4405e2b7c51ad687a280cfe27ebbd))
+
+
+
+
+
 # 1.0.0 (2020-11-12)
 
 

--- a/packages/fetchye-redux-provider/package.json
+++ b/packages/fetchye-redux-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fetchye-redux-provider",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Redux provider for fetchye.",
   "license": "Apache-2.0",
   "main": "lib/index.js",
@@ -43,7 +43,7 @@
     "@testing-library/react": "^11.0.4",
     "babel-preset-amex": "^3.4.1",
     "cross-env": "^7.0.2",
-    "fetchye": "^1.0.0",
+    "fetchye": "^1.0.1",
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {

--- a/packages/fetchye-test-utils/CHANGELOG.md
+++ b/packages/fetchye-test-utils/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 1.0.1 (2020-11-17)
+
+
+### Features
+
+* **fetchye:** prepare for initial release [skip ci] ([#28](https://github.com/americanexpress/fetchye/issues/28)) ([2b212df](https://github.com/americanexpress/fetchye/commit/2b212df8fab4405e2b7c51ad687a280cfe27ebbd))
+
+
+
+
+
 # 1.0.0 (2020-11-12)
 
 

--- a/packages/fetchye-test-utils/package.json
+++ b/packages/fetchye-test-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fetchye-test-utils",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Core components of the Fetchye library",
   "license": "Apache-2.0",
   "main": "lib/index.js",

--- a/packages/fetchye/CHANGELOG.md
+++ b/packages/fetchye/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 1.0.1 (2020-11-17)
+
+
+### Features
+
+* **fetchye:** prepare for initial release [skip ci] ([#28](https://github.com/americanexpress/fetchye/issues/28)) ([2b212df](https://github.com/americanexpress/fetchye/commit/2b212df8fab4405e2b7c51ad687a280cfe27ebbd))
+
+
+
+
+
 # 1.0.0 (2020-11-12)
 
 

--- a/packages/fetchye/package.json
+++ b/packages/fetchye/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fetchye",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "If you know how to use Fetch, you know how to use Fetchye [fetch-yae]. Simple React Hooks, Centralized Cache, Infinitely Extensible.",
   "license": "Apache-2.0",
   "main": "lib/index.js",
@@ -52,7 +52,7 @@
   ],
   "dependencies": {
     "@babel/runtime": "^7.11.2",
-    "fetchye-core": "^1.0.0",
+    "fetchye-core": "^1.0.1",
     "object-hash": "^2.0.3",
     "prop-types": "^15.7.2"
   },
@@ -66,7 +66,7 @@
     "@testing-library/react": "^11.0.4",
     "babel-preset-amex": "^3.4.1",
     "cross-env": "^7.0.2",
-    "fetchye-test-utils": "^1.0.0",
+    "fetchye-test-utils": "^1.0.1",
     "react": "^16.14.0",
     "react-dom": "^16.14.0",
     "react-redux": "^7.2.1",


### PR DESCRIPTION
Due to the fetchye package having been previously published and unpublished it is not possible to release fetchye@1.0.0