### PR TITLE
WIP/Draft: Support for AbortController

### DIFF
--- a/packages/fetchye/src/useFetchye.js
+++ b/packages/fetchye/src/useFetchye.js
@@ -43,6 +43,14 @@ const useFetchye = (
   numOfRenders.current += 1;
 
   useEffect(() => {
+    const controller = new AbortController();
+    const { signal } = controller;
+    // eslint-disable-next-line no-param-reassign
+    options.signal = signal;
+    return () => controller.abort();
+  }, []);
+
+  useEffect(() => {
     if (options.defer || !computedKey) {
       return;
     }


### PR DESCRIPTION
Add support to automatically abort fetch request in flight when a component is dismounted in the default fetcher. Provide the signal as an option to custom fetchers. 

## Description

I wanted to open a **DRAFT/WIP** with a proof of concept to start a conversation on the best way to and if useFetchye should support aborting fetch request. In the current implementation a request will continue even if the component is unmounted as seen in the first gif.

I am proposing that the default fetcher should abort request when the component is unmounted. For use cases where a custom fetch is being used we would forfeit control of the signal by passing it in through the options object so the user can decide to pass it into the fetch request. 

**This pull request is missing pieces before it could be merged but wanted to open it up to feedback before going further.**

**scope**
- Limited to the client. I believe an equal server implementation would be useful but would need to use timeouts instead.
- Browsers that support AbortController

**implementation**
- add a `useEffect` to `packages/fetchye/src/useFetchye.js` that runs once. Creating the new AbortController and calling its abort as part of the clean up phase on unmount.
- pass the signal to the options

**outstanding questions**
- Best way to handle browser support? ( I was thinking a simple feature detection check )
- Currently only passing the signal but would it be more empowering to pass the entire controller?
- Should an eventual solution first be done with a feature flag?
- How to ensure this is only happening on the client

**request not aborting**
![fetchye-abort-none](https://user-images.githubusercontent.com/11730651/113744807-a6be9480-96ca-11eb-8d87-aeb597206f78.gif)

**request aborting**
![fetchye-abort-working](https://user-images.githubusercontent.com/11730651/113747761-55fc6b00-96cd-11eb-9be8-7ed3477acc87.gif)

**passed in to custom fetcher**
![fetchye-abort-args-to-fetcher](https://user-images.githubusercontent.com/11730651/113747811-63b1f080-96cd-11eb-9280-2ea4c4d337c6.gif)



## Motivation and Context
We are currently working on a component that uses the `useFetchye` hook and we noticed during that requests were still being fulfilled even after navigating away from that component (it's unmounted).  

## How Has This Been Tested?
- Tested in a simple demo application that I scaffold here: https://github.com/TatisLois/fetchye-demo
- Needs unit test 

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding or updating documentation)
- [ ] Dependency update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] My changes are in sync with the code style of this project.
- [x ] There aren't any other open Pull Requests for the same issue/update.
- [ ] These changes should be applied to a maintenance branch.
- [ ] I have added the Apache 2.0 license header to any new files created.

## What is the Impact to Developers Using Fetchye?
If the developer is using the default fetch then the request will be aborted if the invoking component is unmounted. If using a custom fetch then the developer will see the signal as an option in the options object.
