### PR TITLE
fix(defaultFetcher): Avoid known hang in node-fetch

### DIFF
--- a/packages/fetchye-core/__tests__/defaultFetcher.spec.js
+++ b/packages/fetchye-core/__tests__/defaultFetcher.spec.js
@@ -26,16 +26,9 @@ describe('defaultFetcher', () => {
     const fetchClient = jest.fn(async () => ({
       ok: true,
       status: 200,
-      json: async () => true,
+      text: async () => JSON.stringify({ jsonBodyMock: 'jsonBodyMock' }),
       headers: new global.Headers({
         'Content-Type': 'application/json',
-      }),
-      clone: () => ({
-        ok: true,
-        status: 200,
-        headers: new global.Headers({
-          'Content-Type': 'application/json',
-        }),
       }),
     }));
     const data = await defaultFetcher(fetchClient, 'http://example.com');
@@ -43,10 +36,32 @@ describe('defaultFetcher', () => {
       Object {
         "error": undefined,
         "payload": Object {
-          "body": true,
+          "body": Object {
+            "jsonBodyMock": "jsonBodyMock",
+          },
           "headers": Object {
             "content-type": "application/json",
           },
+          "ok": true,
+          "status": 200,
+        },
+      }
+    `);
+  });
+  it('should return payload with the raw text body and undefined error when the body cannot be parsed', async () => {
+    const fetchClient = jest.fn(async () => ({
+      ok: true,
+      status: 200,
+      text: async () => 'unparsableTextBodyMock',
+      headers: new global.Headers({}),
+    }));
+    const data = await defaultFetcher(fetchClient, 'http://example.com');
+    expect(data).toMatchInlineSnapshot(`
+      Object {
+        "error": undefined,
+        "payload": Object {
+          "body": "unparsableTextBodyMock",
+          "headers": Object {},
           "ok": true,
           "status": 200,
         },
@@ -57,20 +72,17 @@ describe('defaultFetcher', () => {
     const fetchClient = jest.fn(async () => ({
       ok: true,
       status: 200,
-      json: async () => true,
+      text: async () => JSON.stringify({ jsonBodyMock: 'jsonBodyMock' }),
       headers: undefined,
-      clone: () => ({
-        ok: true,
-        status: 200,
-        headers: undefined,
-      }),
     }));
     const data = await defaultFetcher(fetchClient, 'http://example.com');
     expect(data).toMatchInlineSnapshot(`
       Object {
         "error": undefined,
         "payload": Object {
-          "body": true,
+          "body": Object {
+            "jsonBodyMock": "jsonBodyMock",
+          },
           "headers": Object {},
           "ok": true,
           "status": 200,
@@ -95,14 +107,8 @@ describe('defaultFetcher', () => {
     const fetchClient = jest.fn(async () => ({
       ok: true,
       status: 204,
-      json: async () => { throw new SyntaxError('Unexpected end of JSON input'); },
+      text: async () => '',
       headers: new global.Headers({}),
-      clone: () => ({
-        ok: true,
-        status: 204,
-        headers: new global.Headers({}),
-        text: async () => '',
-      }),
     }));
     const data = await defaultFetcher(fetchClient, 'http://example.com');
     expect(data).toMatchInlineSnapshot(`

--- a/packages/fetchye-core/src/defaultFetcher.js
+++ b/packages/fetchye-core/src/defaultFetcher.js
@@ -27,8 +27,13 @@ export const defaultFetcher = async (fetchClient, key, options) => {
   let error;
   try {
     res = await fetchClient(key, options);
-    const responseClone = res.clone();
-    const body = await res.json().catch(() => responseClone.text());
+    let body = await res.text();
+    try {
+      body = JSON.parse(body);
+      // eslint-disable-next-line no-empty
+    } catch (e) {
+      // body will still be the text from the response, so no action needed here
+    }
     payload = {
       body,
       ok: res.ok,

--- a/packages/fetchye/__tests__/makeServerFetchye.spec.js
+++ b/packages/fetchye/__tests__/makeServerFetchye.spec.js
@@ -29,15 +29,8 @@ const defaultPayload = {
   }),
   ok: true,
   status: 200,
-  json: async () => ({
+  text: async () => JSON.stringify({
     fakeData: true,
-  }),
-  clone: () => ({
-    headers: new global.Headers({
-      'Content-Type': 'application/json',
-    }),
-    ok: true,
-    status: 200,
   }),
 };
 

--- a/packages/fetchye/__tests__/useFetchye.spec.jsx
+++ b/packages/fetchye/__tests__/useFetchye.spec.jsx
@@ -31,15 +31,8 @@ const defaultPayload = {
   }),
   ok: true,
   status: 200,
-  json: async () => ({
+  text: async () => JSON.stringify({
     fakeData: true,
-  }),
-  clone: () => ({
-    headers: new global.Headers({
-      'Content-Type': 'application/json',
-    }),
-    ok: true,
-    status: 200,
   }),
 };
 
@@ -125,13 +118,7 @@ describe('useFetchye', () => {
         global.fetch = jest.fn(async () => ({
           ...defaultPayload,
           status: 204,
-          json: async () => { throw new SyntaxError('Unexpected end of JSON input'); },
-          clone: () => ({
-            ok: true,
-            status: 204,
-            headers: new global.Headers({}),
-            text: async () => '',
-          }),
+          text: async () => '',
         }));
         render(
           <AFetchyeProvider cache={cache}>
@@ -165,14 +152,14 @@ describe('useFetchye', () => {
           if (url === 'http://example.com/one') {
             return {
               ...defaultPayload,
-              json: async () => ({
+              text: async () => JSON.stringify({
                 id: 'abc123',
               }),
             };
           }
           return {
             ...defaultPayload,
-            json: async () => ({
+            text: async () => JSON.stringify({
               resourceUrl: url,
             }),
           };
@@ -271,7 +258,7 @@ describe('useFetchye', () => {
             payload: {
               ok: res.ok,
               status: res.status,
-              body: await res.json(),
+              body: JSON.parse(await res.text()),
             },
             error: undefined,
           };
@@ -340,9 +327,7 @@ describe('useFetchye', () => {
     ].forEach(([name, AFetchyeProvider]) => {
       describe(name, () => {
         it('ensures fetch is called once per key', async () => {
-          const fakeFetchClient = jest.fn({
-            clone: () => {},
-          });
+          const fakeFetchClient = jest.fn();
           global.fetch = fakeFetchClient;
           render(
             <AFetchyeProvider cache={cache}>


### PR DESCRIPTION
There is a known hang in node-fetch. We avoid it by avoiding the clone function.

## Description
As per https://github.com/node-fetch/node-fetch#custom-highwatermark there is a known hang when consuming the body of a request with a response that is larger than the default buffer size.

In this PR I avoid this hang by removing the call to .clone(). Instead we always read the body as text, and then try and parse it ourselves.

## Motivation and Context
This change prevents instances where requests in nodeJS (such as during SSR uses of fetchye) would indefinitely hang.

## How Has This Been Tested?
Using fetchye as part of a One App module, I have created SSR requests that tests the correct behaviour for both json payloads and non-json payloads.
I would have liked to have added a unit test that would have failed for the old code, however since we completely mock out node-fetch in the tests, there is no way to reproduce this hang.
Ive modified the unit tests to ensure that the old behaviour has been maintained. This required more changes to tests than I would have liked, however since the 'happy' case now relies on the body of the request being parsable JSON these changes were needed.

## Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding or updating documentation)
- [ ] Dependency update

## Checklist:
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [x] My changes are in sync with the code style of this project.
- [x] There aren't any other open Pull Requests for the same issue/update.
- [ ] These changes should be applied to a maintenance branch.
- [ ] I have added the Apache 2.0 license header to any new files created.

## What is the Impact to Developers Using Fetchye?
There should be no impact for developers as there should be no change to the api. 
