### PR TITLE
fix(FetchyeProvider): correct stale data bug

### DIFF
--- a/packages/fetchye/__tests__/__snapshots__/FetchyeProvider.spec.jsx.snap
+++ b/packages/fetchye/__tests__/__snapshots__/FetchyeProvider.spec.jsx.snap
@@ -1,0 +1,43 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`FetchyeProvider should return a stable response from useFetchyeSelector that changes properly with a changed input 1`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      Object {
+        "data": "val1",
+        "error": undefined,
+        "loading": false,
+      },
+    ],
+    Array [
+      Object {
+        "data": "val1",
+        "error": undefined,
+        "loading": false,
+      },
+    ],
+    Array [
+      Object {
+        "data": "val2",
+        "error": undefined,
+        "loading": false,
+      },
+    ],
+  ],
+  "results": Array [
+    Object {
+      "type": "return",
+      "value": undefined,
+    },
+    Object {
+      "type": "return",
+      "value": undefined,
+    },
+    Object {
+      "type": "return",
+      "value": undefined,
+    },
+  ],
+}
+`;

--- a/packages/fetchye/src/FetchyeProvider.jsx
+++ b/packages/fetchye/src/FetchyeProvider.jsx
@@ -34,8 +34,6 @@ const makeUseFetchyeSelector = ({
   const selectorValue = useRef(initialValue);
 
   useEffect(() => {
-    selectorValue.current = getCacheByKey(fetchyeState.current, key);
-
     function checkForUpdates() {
       const nextValue = getCacheByKey(fetchyeState.current, key);
       lastSelectorValue.current = selectorValue.current;


### PR DESCRIPTION
This PR implements the same fix as [PR46](https://github.com/americanexpress/fetchye/pull/46) but for FetchyeProvider

<!--- Provide a general summary of your changes in the Title above -->

## Description
Ensure the effect in the default selector properly causes a re-render when the key changes.

## Motivation and Context
Without this change, when 'returning' to data that is already loaded in the cache, the data returned by 'useFetchye' ends up 'one render behind'.
This fix ensures that a change in the key results in an additional render to keep the value up to date.

## How Has This Been Tested?
A Unit test has been created that would fail for the old code, which passes for the new code
Using fetchye as part of a One App module, I have recreated this issue using a list of data where selecting an item causes a call to useFetchye in a separate module. Without this fix, when navigating back to a previously visited item, the second module ends up one click behind. With this fix the second module always shows the correct item.
No existing unit tests failed.


## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding or updating documentation)
- [ ] Dependency update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [x] My changes are in sync with the code style of this project.
- [x] There aren't any other open Pull Requests for the same issue/update.
- [ ] These changes should be applied to a maintenance branch.
- [ ] I have added the Apache 2.0 license header to any new files created.

## What is the Impact to Developers Using Fetchye?
There should be no impact to developers as there is no change to an api.
