### PR TITLE
fix(peerDeps): creating fix commit for versioning reasons

### DIFF
--- a/packages/fetchye/package.json
+++ b/packages/fetchye/package.json
@@ -48,7 +48,8 @@
     "Nickolas Oliver <nickolas.oliver@aexp.com> (https://github.com/PixnBits)",
     "Andrew Curtis <andrew.curtis@aexp.com> (https://github.com/drewcur)",
     "Scott McIntyre <scott.mcintyre@aexp.com> (https://github.com/smackfu)",
-    "Ruben Casas <ruben.casas@aexp.com> (https://github.com/infoxicator)"
+    "Ruben Casas <ruben.casas@aexp.com> (https://github.com/infoxicator)",
+    "Matthew Mallimo <matthew.c.mallimo@aexp.com> (https://github.com/Matthew-Mallimo)"
   ],
   "dependencies": {
     "@babel/runtime": "^7.11.2",


### PR DESCRIPTION
Just adding a fix commit, since the peerDeps commit (073855f9c9333f49c66d93739fbad00dec15249d) was marked as a chore. This is needed to get our versioning to work