### PR TITLE
fix(cache): remove previous data or error on new run

### DIFF
--- a/packages/fetchye-immutable-cache/__tests__/__snapshots__/ImmutableCache.spec.js.snap
+++ b/packages/fetchye-immutable-cache/__tests__/__snapshots__/ImmutableCache.spec.js.snap
@@ -105,3 +105,29 @@ Immutable.Map {
   "data": Immutable.Map {},
 }
 `;
+
+exports[`ImmutableCache should reflect load to error to success state 1`] = `
+Immutable.Map {
+  "errors": Immutable.Map {},
+  "loading": Immutable.Set [],
+  "data": Immutable.Map {
+    "abc1234": Object {
+      "body": Object {
+        "fakeData": true,
+      },
+      "ok": true,
+      "status": 200,
+    },
+  },
+}
+`;
+
+exports[`ImmutableCache should reflect load to success to error state 1`] = `
+Immutable.Map {
+  "errors": Immutable.Map {
+    "abc1234": [Error: Fake Error],
+  },
+  "loading": Immutable.Set [],
+  "data": Immutable.Map {},
+}
+`;

--- a/packages/fetchye-immutable-cache/__tests__/reducer.spec.js
+++ b/packages/fetchye-immutable-cache/__tests__/reducer.spec.js
@@ -21,7 +21,6 @@ import {
   deleteAction,
   errorAction,
   clearErrorsAction,
-
 } from 'fetchye-core';
 import reducer from '../src/reducer';
 
@@ -124,6 +123,38 @@ describe('Immutable Reducer', () => {
         "errors": Immutable.Map {},
         "loading": Immutable.Set [],
         "data": Immutable.Map {},
+      }
+    `);
+  });
+  it('should reflect load to success to error state', () => {
+    const { dispatch, getState } = store;
+    createScenario(dispatch, ['loadingAction', 'setAction', 'errorAction'], 'abc1234');
+    expect(getState()).toMatchInlineSnapshot(`
+      Immutable.Map {
+        "errors": Immutable.Map {
+          "abc1234": [Error: Fake Error],
+        },
+        "loading": Immutable.Set [],
+        "data": Immutable.Map {},
+      }
+    `);
+  });
+  it('should reflect load to error to success state', () => {
+    const { dispatch, getState } = store;
+    createScenario(dispatch, ['loadingAction', 'errorAction', 'setAction'], 'abc1234');
+    expect(getState()).toMatchInlineSnapshot(`
+      Immutable.Map {
+        "errors": Immutable.Map {},
+        "loading": Immutable.Set [],
+        "data": Immutable.Map {
+          "abc1234": Object {
+            "body": Object {
+              "fakeData": true,
+            },
+            "ok": true,
+            "status": 200,
+          },
+        },
       }
     `);
   });

--- a/packages/fetchye-immutable-cache/src/reducer.js
+++ b/packages/fetchye-immutable-cache/src/reducer.js
@@ -43,6 +43,7 @@ export function fetchyeReducer(state = iMap({
       return state.withMutations(
         (nextState) => nextState
           .setIn(['errors', action.hash], action.error)
+          .deleteIn(['data', action.hash])
           .deleteIn(['loading', action.hash])
       );
     case IS_LOADING:
@@ -50,8 +51,9 @@ export function fetchyeReducer(state = iMap({
     case SET_DATA:
       return state.withMutations(
         (nextState) => nextState
-          .deleteIn(['loading', action.hash])
           .setIn(['data', action.hash], action.value)
+          .deleteIn(['loading', action.hash])
+          .deleteIn(['errors', action.hash])
       );
     default:
       return state;

--- a/packages/fetchye-test-utils/src/testCacheInterface.js
+++ b/packages/fetchye-test-utils/src/testCacheInterface.js
@@ -88,6 +88,16 @@ export function testCacheInterface(CacheFunc) {
     createScenario(dispatch, ['loadingAction', 'errorAction', 'clearErrorsAction'], 'abc1234');
     expect(getState()).toMatchSnapshot();
   });
+  it('should reflect load to success to error state', () => {
+    const { dispatch, getState } = store;
+    createScenario(dispatch, ['loadingAction', 'setAction', 'errorAction'], 'abc1234');
+    expect(getState()).toMatchSnapshot();
+  });
+  it('should reflect load to error to success state', () => {
+    const { dispatch, getState } = store;
+    createScenario(dispatch, ['loadingAction', 'errorAction', 'setAction'], 'abc1234');
+    expect(getState()).toMatchSnapshot();
+  });
   it('reflects multiple hashes stored', () => {
     const { dispatch, getState } = store;
     createScenario(dispatch, ['loadingAction', 'setAction'], 'abc1234');

--- a/packages/fetchye/__tests__/__snapshots__/SimpleCache.spec.js.snap
+++ b/packages/fetchye/__tests__/__snapshots__/SimpleCache.spec.js.snap
@@ -105,3 +105,29 @@ Object {
   "loading": Object {},
 }
 `;
+
+exports[`SimpleCache should reflect load to error to success state 1`] = `
+Object {
+  "data": Object {
+    "abc1234": Object {
+      "body": Object {
+        "fakeData": true,
+      },
+      "ok": true,
+      "status": 200,
+    },
+  },
+  "errors": Object {},
+  "loading": Object {},
+}
+`;
+
+exports[`SimpleCache should reflect load to success to error state 1`] = `
+Object {
+  "data": Object {},
+  "errors": Object {
+    "abc1234": [Error: Fake Error],
+  },
+  "loading": Object {},
+}
+`;

--- a/packages/fetchye/src/SimpleCache.js
+++ b/packages/fetchye/src/SimpleCache.js
@@ -53,9 +53,13 @@ function reducer(state = {
       };
     }
     case ERROR: {
-      const { [action.hash]: deletedEntry, ...nextLoading } = state.loading;
+      const { [action.hash]: deletedLoadingEntry, ...nextLoading } = state.loading;
+      const { [action.hash]: deletedDataEntry, ...nextData } = state.data;
       return {
         ...state,
+        data: {
+          ...nextData,
+        },
         errors: {
           ...state.errors,
           [action.hash]: action.error,
@@ -75,12 +79,16 @@ function reducer(state = {
       };
     }
     case SET_DATA: {
-      const { [action.hash]: deletedEntry, ...nextLoading } = state.loading;
+      const { [action.hash]: deletedLoadingEntry, ...nextLoading } = state.loading;
+      const { [action.hash]: deletedErrorEntry, ...nextErrors } = state.errors;
       return {
         ...state,
         data: {
           ...state.data,
           [action.hash]: action.value,
+        },
+        errors: {
+          ...nextErrors,
         },
         loading: {
           ...nextLoading,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
If there is now data, remove the error from the previous run.
If there is now an error, remove the data from the previous run.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Sometimes there might be network issues (ex: traveling into a tunnel so the network disconnects) and a retry is desirable. As an example, a manual retry could be:
```jsx
function BookList({ genre }) {
  const { isLoading, data, error, run } = useFetchye(`https://example.com/api/books/?genre=${genre}`;

  if (isLoading) {
    return (<p>Loading...</p>);
  }
  
  if (error || !data?.ok) {
    return (
      <>
        <p>Error encountered when loading the books</p>
        {error && <pre>{error.message}</pre>}
        <button type="button" onClick={run}>
          Retry
        </button>
      </>
    );
  }

  return (
    <>
      <p>Books!<p>
      <pre>{JSON.stringify(data.body, null, 2)}</pre>
    </>
  );
}
```
Currently, if there was an error the first load attempt `error` has a value (and `data` does not). However, on the second attempt if the request does go through and `data` now has a value `error` still has a value, persisted from the first attempt.

We can add an automatic retry to hit another scenario:
```jsx
  // retry loading after five seconds when we don't have a usable response
  useEffect(() => {
    if (isLoading || data?.ok) {
      return;
    }
    const timeoutHandle = setTimeout(run, 5_000);
    return () => clearTimeout(timeoutHandle);
  }, [isLoading, data, error, run]);
```

If the first attempt is successful and `data` has a value (and `error` does not), but on the second attempt there is an error then `error` now has a value but `data` still has a value, persisted from the first attempt.

Additionally, with both entries having values it is difficult which of `data` or `error` are more recent. This is probably not too much of a concern for idempotent calls (e.g. `GET`) but this may cause challenges for mutating/non-idempotent calls (e.g. `POST`).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tests, keeping with their context, have been added. When generating snapshots Jest noted that it could not find Prettier, likely after the eslint configuration update; I installed Prettier locally to generate the inline snapshots but another PR will be needed to avoid this in the future.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding or updating documentation)
- [ ] Dependency update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [x] My changes are in sync with the code style of this project.
- [x] There aren't any other open Pull Requests for the same issue/update.
- [x] These changes should be applied to a maintenance branch.
- [ ] I have added the Apache 2.0 license header to any new files created.

## What is the Impact to Developers Using Fetchye?
<!--- Please describe how your changes impacts developers using Fetchye. -->

Some developers might be, perhaps unknowingly, relying on the current behavior. Generally though I see the current behavior as a bug especially due to the challenge of knowing which of `data` or `error` are most recent. If a component wishes to use the last available `data` before errors were encountered their best course of action is probably adding their logic needed using `useState` and `useEffect`, e.g.:
```jsx
const [lastKnownData, setLastKnownData] = useState(data);
  useEffect(() => {
    if (!data) {
      return;
    }
    setLastKnownData(data);
  }, [data]);
```
or, if response status is important
```jsx
if (!data?.ok) {
```
or
```jsx
if (data?.status !== 200) {
```
depending on their specific circumstances