### PR TITLE
chore(release): v1.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.1.2](https://github.com/americanexpress/fetchye/compare/v1.1.0...v1.1.2) (2022-10-21)
+
+
+### Bug Fixes
+
+* **cache:** remove previous data or error on new run ([#66](https://github.com/americanexpress/fetchye/issues/66)) ([f921ef3](https://github.com/americanexpress/fetchye/commit/f921ef301c7ac28172772acccae0f6274cf76225))
+* **peerDeps:** creating fix commit for versioning reasons ([#60](https://github.com/americanexpress/fetchye/issues/60)) ([f63a28e](https://github.com/americanexpress/fetchye/commit/f63a28e09b0796870c5d8b8388ebbdc4bd8639f9))
+
+
+
+
+
 ## [1.1.1](https://github.com/americanexpress/fetchye/compare/v1.1.0...v1.1.1) (2022-07-05)
 
 

--- a/lerna.json
+++ b/lerna.json
@@ -10,5 +10,5 @@
       "allowBranch": "chore/release-*"
     }
   },
-  "version": "1.1.1"
+  "version": "1.1.2"
 }

--- a/packages/fetchye-core/CHANGELOG.md
+++ b/packages/fetchye-core/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.1.2](https://github.com/americanexpress/fetchye/compare/v1.1.0...v1.1.2) (2022-10-21)
+
+**Note:** Version bump only for package fetchye-core
+
+
+
+
+
 ## [1.1.1](https://github.com/americanexpress/fetchye/compare/v1.1.0...v1.1.1) (2022-07-05)
 
 **Note:** Version bump only for package fetchye-core

--- a/packages/fetchye-core/package.json
+++ b/packages/fetchye-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fetchye-core",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Core components of the Fetchye library",
   "license": "Apache-2.0",
   "main": "lib/index.js",

--- a/packages/fetchye-immutable-cache/CHANGELOG.md
+++ b/packages/fetchye-immutable-cache/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.1.2](https://github.com/americanexpress/fetchye/compare/v1.1.0...v1.1.2) (2022-10-21)
+
+
+### Bug Fixes
+
+* **cache:** remove previous data or error on new run ([#66](https://github.com/americanexpress/fetchye/issues/66)) ([f921ef3](https://github.com/americanexpress/fetchye/commit/f921ef301c7ac28172772acccae0f6274cf76225))
+
+
+
+
+
 ## [1.1.1](https://github.com/americanexpress/fetchye/compare/v1.1.0...v1.1.1) (2022-07-05)
 
 **Note:** Version bump only for package fetchye-immutable-cache

--- a/packages/fetchye-immutable-cache/package.json
+++ b/packages/fetchye-immutable-cache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fetchye-immutable-cache",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Immutable cache library to use with fetchye.",
   "license": "Apache-2.0",
   "main": "lib/index.js",
@@ -42,7 +42,7 @@
     "@babel/core": "7.11.6",
     "babel-preset-amex": "^3.4.1",
     "cross-env": "^7.0.2",
-    "fetchye-test-utils": "^1.1.1",
+    "fetchye-test-utils": "^1.1.2",
     "redux": "^4.0.5",
     "rimraf": "^3.0.2"
   },

--- a/packages/fetchye-one-app/CHANGELOG.md
+++ b/packages/fetchye-one-app/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.1.2](https://github.com/americanexpress/fetchye/compare/v1.1.0...v1.1.2) (2022-10-21)
+
+**Note:** Version bump only for package fetchye-one-app
+
+
+
+
+
 ## [1.1.1](https://github.com/americanexpress/fetchye/compare/v1.1.0...v1.1.1) (2022-07-05)
 
 **Note:** Version bump only for package fetchye-one-app

--- a/packages/fetchye-one-app/package.json
+++ b/packages/fetchye-one-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fetchye-one-app",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Collection of helpers to aid fetchye integration with One App",
   "license": "Apache-2.0",
   "main": "lib/index.js",
@@ -40,9 +40,9 @@
   ],
   "dependencies": {
     "@babel/runtime": "^7.11.2",
-    "fetchye-immutable-cache": "^1.1.1",
-    "fetchye-redux-provider": "^1.1.1",
-    "fetchye-test-utils": "^1.1.1",
+    "fetchye-immutable-cache": "^1.1.2",
+    "fetchye-redux-provider": "^1.1.2",
+    "fetchye-test-utils": "^1.1.2",
     "invariant": "^2.2.4",
     "prop-types": "^15.7.2"
   },
@@ -57,7 +57,7 @@
     "@testing-library/react": "^11.0.4",
     "babel-preset-amex": "^3.4.1",
     "cross-env": "^7.0.2",
-    "fetchye-core": "^1.1.1",
+    "fetchye-core": "^1.1.2",
     "immutable": "^4.0.0-rc.12",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",

--- a/packages/fetchye-redux-provider/CHANGELOG.md
+++ b/packages/fetchye-redux-provider/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.1.2](https://github.com/americanexpress/fetchye/compare/v1.1.0...v1.1.2) (2022-10-21)
+
+**Note:** Version bump only for package fetchye-redux-provider
+
+
+
+
+
 ## [1.1.1](https://github.com/americanexpress/fetchye/compare/v1.1.0...v1.1.1) (2022-07-05)
 
 **Note:** Version bump only for package fetchye-redux-provider

--- a/packages/fetchye-redux-provider/package.json
+++ b/packages/fetchye-redux-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fetchye-redux-provider",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Redux provider for fetchye.",
   "license": "Apache-2.0",
   "main": "lib/index.js",
@@ -43,7 +43,7 @@
     "@testing-library/react": "^11.0.4",
     "babel-preset-amex": "^3.4.1",
     "cross-env": "^7.0.2",
-    "fetchye": "^1.1.1",
+    "fetchye": "^1.1.2",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "rimraf": "^3.0.2"

--- a/packages/fetchye-test-utils/CHANGELOG.md
+++ b/packages/fetchye-test-utils/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.1.2](https://github.com/americanexpress/fetchye/compare/v1.1.0...v1.1.2) (2022-10-21)
+
+
+### Bug Fixes
+
+* **cache:** remove previous data or error on new run ([#66](https://github.com/americanexpress/fetchye/issues/66)) ([f921ef3](https://github.com/americanexpress/fetchye/commit/f921ef301c7ac28172772acccae0f6274cf76225))
+
+
+
+
+
 ## [1.1.1](https://github.com/americanexpress/fetchye/compare/v1.1.0...v1.1.1) (2022-07-05)
 
 **Note:** Version bump only for package fetchye-test-utils

--- a/packages/fetchye-test-utils/package.json
+++ b/packages/fetchye-test-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fetchye-test-utils",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Core components of the Fetchye library",
   "license": "Apache-2.0",
   "main": "lib/index.js",

--- a/packages/fetchye/CHANGELOG.md
+++ b/packages/fetchye/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.1.2](https://github.com/americanexpress/fetchye/compare/v1.1.0...v1.1.2) (2022-10-21)
+
+
+### Bug Fixes
+
+* **cache:** remove previous data or error on new run ([#66](https://github.com/americanexpress/fetchye/issues/66)) ([f921ef3](https://github.com/americanexpress/fetchye/commit/f921ef301c7ac28172772acccae0f6274cf76225))
+* **peerDeps:** creating fix commit for versioning reasons ([#60](https://github.com/americanexpress/fetchye/issues/60)) ([f63a28e](https://github.com/americanexpress/fetchye/commit/f63a28e09b0796870c5d8b8388ebbdc4bd8639f9))
+
+
+
+
+
 ## [1.1.1](https://github.com/americanexpress/fetchye/compare/v1.1.0...v1.1.1) (2022-07-05)
 
 

--- a/packages/fetchye/package.json
+++ b/packages/fetchye/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fetchye",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "If you know how to use Fetch, you know how to use Fetchye [fetch-yae]. Simple React Hooks, Centralized Cache, Infinitely Extensible.",
   "license": "Apache-2.0",
   "main": "lib/index.js",
@@ -53,7 +53,7 @@
   ],
   "dependencies": {
     "@babel/runtime": "^7.11.2",
-    "fetchye-core": "^1.1.1",
+    "fetchye-core": "^1.1.2",
     "object-hash": "^2.0.3",
     "prop-types": "^15.7.2"
   },
@@ -67,7 +67,7 @@
     "@testing-library/react": "^11.0.4",
     "babel-preset-amex": "^3.4.1",
     "cross-env": "^7.0.2",
-    "fetchye-test-utils": "^1.1.1",
+    "fetchye-test-utils": "^1.1.2",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-redux": "^7.2.1",


### PR DESCRIPTION
Release v1.1.2 includes
- **cache:** remove previous data or error on new run
- **peerDeps:** creating fix commit for versioning reasons
