### PR TITLE
feat(fetchye): support headers as a function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,4 +31,5 @@ __diff_output__
 *.bak
 *.cya
 .vscode
+.idea
 *.tgz

--- a/README.md
+++ b/README.md
@@ -597,7 +597,7 @@ To overcome this, you can specify a function instead of a `headers` object in th
 
 This function will be called, to re-make the headers just before an API call is made, even when you call `run`.
 
-Note: You still need to remove dynamic keys from the options using `mapOptionsToKey` otherwise these dynamic headers will bust your cache!
+Note: If you don't want the dynamic headers to result in a cache miss, you must remove the keys of the dynamic headers from the options using `mapOptionsToKey` (see example below).
 
 ```jsx
 import React from 'react';

--- a/packages/fetchye/__tests__/handleDynamicHeaders.spec.js
+++ b/packages/fetchye/__tests__/handleDynamicHeaders.spec.js
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2023 American Express Travel Related Services Company, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import { handleDynamicHeaders } from '../src/handleDynamicHeaders';
+
+describe('handleDynamicHeaders', () => {
+  it('should pass back the exact object passed if the headers field is not a function', () => {
+    const testValues = [
+      {},
+      { body: 'mockBody' },
+      { headers: {} },
+      { headers: 1 },
+      { headers: { staticHeader: 'staticHeaderValue' } },
+      // The function should be resistant to being passed non objects too
+      Symbol('testSymbol'),
+      'value',
+      1234,
+    ];
+
+    testValues.forEach((testVal) => {
+      expect(handleDynamicHeaders(testVal)).toBe(testVal);
+    });
+  });
+
+  it('should pass back a new object with the headers handled, and other values preserved, when the headers field is a function', () => {
+    const testValues = [
+      {},
+      { body: 'mockBody' },
+      { options: { staticOption: 'staticOptionValue' } },
+      { symbol: Symbol('testSymbol') },
+    ];
+
+    testValues.forEach((testVal) => {
+      const valWithDynamicHeader = {
+        ...testVal,
+        headers: jest.fn(() => ({
+          dynamicHeader: 'dynamicHeaderValue',
+        })),
+      };
+
+      const result = handleDynamicHeaders(valWithDynamicHeader);
+
+      // a new object has been created
+      expect(result).not.toBe(valWithDynamicHeader);
+
+      // the headers are no-loger a function
+      expect(result.headers).toEqual({
+        dynamicHeader: 'dynamicHeaderValue',
+      });
+
+      // all other keys are preserved
+      Object.keys(testVal).forEach((testValKey) => {
+        expect(result[testValKey]).toBe(testVal[testValKey]);
+      });
+    });
+  });
+});

--- a/packages/fetchye/__tests__/useFetchye.spec.jsx
+++ b/packages/fetchye/__tests__/useFetchye.spec.jsx
@@ -122,9 +122,9 @@ describe('useFetchye', () => {
           <AFetchyeProvider cache={cache}>
             {React.createElement(() => {
               fetchyeRes = useFetchye('http://example.com', {
-                headers: {
+                headers: () => ({
                   dynamicHeader: 'dynamic value',
-                },
+                }),
               });
               return null;
             })}

--- a/packages/fetchye/__tests__/useFetchye.spec.jsx
+++ b/packages/fetchye/__tests__/useFetchye.spec.jsx
@@ -113,6 +113,37 @@ describe('useFetchye', () => {
           }
         `);
       });
+      it('should call fetch with the right headers when passed dynamic headers', async () => {
+        let fetchyeRes;
+        global.fetch = jest.fn(async () => ({
+          ...defaultPayload,
+        }));
+        render(
+          <AFetchyeProvider cache={cache}>
+            {React.createElement(() => {
+              fetchyeRes = useFetchye('http://example.com', {
+                headers: {
+                  dynamicHeader: 'dynamic value',
+                },
+              });
+              return null;
+            })}
+          </AFetchyeProvider>
+        );
+        await waitFor(() => fetchyeRes.isLoading === false);
+        expect(global.fetch.mock.calls).toMatchInlineSnapshot(`
+          Array [
+            Array [
+              "http://example.com",
+              Object {
+                "headers": Object {
+                  "dynamicHeader": "dynamic value",
+                },
+              },
+            ],
+          ]
+        `);
+      });
       it('should return data success state when response is empty (204 no content)', async () => {
         let fetchyeRes;
         global.fetch = jest.fn(async () => ({
@@ -242,6 +273,34 @@ describe('useFetchye', () => {
               "http://example.com/one",
               Object {
                 "defer": true,
+              },
+            ],
+          ]
+        `);
+      });
+      it('should return data when run method is called with dynamic headers', async () => {
+        let fetchyeRes;
+        global.fetch = jest.fn(async () => ({
+          ...defaultPayload,
+        }));
+        render(
+          <AFetchyeProvider cache={cache}>
+            {React.createElement(() => {
+              fetchyeRes = useFetchye('http://example.com/one', { defer: true, headers: () => ({ dynamicHeader: 'dynamic value' }) });
+              return null;
+            })}
+          </AFetchyeProvider>
+        );
+        await fetchyeRes.run();
+        expect(global.fetch.mock.calls).toMatchInlineSnapshot(`
+          Array [
+            Array [
+              "http://example.com/one",
+              Object {
+                "defer": true,
+                "headers": Object {
+                  "dynamicHeader": "dynamic value",
+                },
               },
             ],
           ]

--- a/packages/fetchye/src/handleDynamicHeaders.js
+++ b/packages/fetchye/src/handleDynamicHeaders.js
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2023 American Express Travel Related Services Company, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+export const handleDynamicHeaders = (options) => {
+  if (typeof options.headers === 'function') {
+    return {
+      ...options,
+      headers: options.headers(),
+    };
+  }
+  return options;
+};


### PR DESCRIPTION
## Description
Support a way of passing 'dynamic headers'

## Motivation and Context
This allows some headers to be created at the time the api call is actually made, including when the `run` function is called.

This significantly reduces the boiler plate required to otherwise achieve this functionality.

## How Has This Been Tested?
Unit tests
No existing tests failing proves this is fully backwards compatible

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding or updating documentation)
- [ ] Dependency update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation and I have updated the documentation accordingly.
- [x] My changes are in sync with the code style of this project.
- [x] There aren't any other open Pull Requests for the same issue/update.
- [ ] These changes should be applied to a maintenance branch.
- [x] I have added the Apache 2.0 license header to any new files created.

## What is the Impact to Developers Using Fetchye?
New feature
