### PR TITLE
Fix/is loading/multi render behaviour weirdness

### DIFF
--- a/packages/fetchye/__tests__/queryHelpers.spec.js
+++ b/packages/fetchye/__tests__/queryHelpers.spec.js
@@ -21,22 +21,43 @@ import {
 describe('isLoading', () => {
   it('should return true if loading cache true', () => {
     expect(isLoading({
-      loading: true, data: undefined, numOfRenders: 2, options: {},
+      loading: true, data: undefined, numOfRenders: 2, options: {}, error: undefined,
     })).toEqual(true);
   });
+
   it('should return true if first render is true', () => {
     expect(isLoading({
-      loading: false, data: undefined, numOfRenders: 1, options: { },
+      loading: false, data: undefined, numOfRenders: 1, options: { }, error: undefined,
     })).toEqual(true);
   });
+
   it('should return false if first render is true and defer is true', () => {
     expect(isLoading({
-      loading: false, data: undefined, numOfRenders: 1, options: { defer: true },
+      loading: false, data: undefined, numOfRenders: 1, options: { defer: true }, error: undefined,
     })).toEqual(false);
   });
-  it('should return false if all args are false', () => {
+
+  it('should return false if numberOfRenders > 1 and defer is true', () => {
     expect(isLoading({
-      loading: false, numOfRenders: 2, options: { defer: false },
+      loading: false, numOfRenders: 2, options: { defer: true }, error: undefined,
+    })).toEqual(false);
+  });
+
+  it('should return true if all args are false', () => {
+    expect(isLoading({
+      loading: false, numOfRenders: 2, options: { defer: false }, error: undefined,
+    })).toEqual(true);
+  });
+
+  it('should return false if there are errors present', () => {
+    expect(isLoading({
+      loading: false, numOfRenders: 2, options: { defer: false }, error: { },
+    })).toEqual(false);
+  });
+
+  it('should return false if there is data present', () => {
+    expect(isLoading({
+      loading: false, data: { }, numOfRenders: 2, options: { defer: false },
     })).toEqual(false);
   });
 });

--- a/packages/fetchye/src/queryHelpers.js
+++ b/packages/fetchye/src/queryHelpers.js
@@ -15,7 +15,7 @@
  */
 
 export const isLoading = ({
-  loading, data, numOfRenders, options,
+  loading, data, numOfRenders, options, error,
 }) => {
   // If first render
   if (numOfRenders === 1) {
@@ -35,6 +35,11 @@ export const isLoading = ({
     // isLoading should be true
     return true;
   }
+  // Here to mimic what happens in the useEffect
+  if (!options.defer && !loading && !data && !error) {
+    return true;
+  }
+
   // else isLoading should be false
   return false;
 };

--- a/packages/fetchye/src/useFetchye.js
+++ b/packages/fetchye/src/useFetchye.js
@@ -63,6 +63,7 @@ const useFetchye = (
       data: selectorState.current.data || options.initialData?.data,
       numOfRenders: numOfRenders.current,
       options,
+      error: selectorState.current.error,
     }),
     error: passInitialData(
       selectorState.current.error,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->

There is a small edge case where when a call is waiting for another call to finish - think A2 needs data from A1.
on the first render
A2 options.defer = true; isLoading == false as a result;
A1 options.defer = false && data = undefined; isLoading == true as a result;

After A1 data has been fetched, A2 options.defer = false. 
However because it isn't the first render isLoading == false, and the loading state is only set to true during the runAsync function call.

To remidy this I've added an extra check that is the same as the check in the useEffect which will be checking `(!options.defer && !data && !isLoading && !error)` if all of these statements are true then we can assume that the `runAsync` function will be triggered in the useEffect.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
potentially solves issue #81 
Also potentially solves an issue found by a team in American express.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
No manual testing done yet.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding or updating documentation)
- [ ] Dependency update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [x] My changes are in sync with the code style of this project.
- [x] There aren't any other open Pull Requests for the same issue/update.
- [ ] These changes should be applied to a maintenance branch.
- [ ] I have added the Apache 2.0 license header to any new files created.

## What is the Impact to Developers Using Fetchye?
<!--- Please describe how your changes impacts developers using Fetchye. -->
